### PR TITLE
Exercise one, update vm image sku.

### DIFF
--- a/lab-1/begin/createUiDefinition.json
+++ b/lab-1/begin/createUiDefinition.json
@@ -68,14 +68,14 @@
                         "label": "Virtual machine size",
                         "toolTip": "The size of the virtual machine",
                         "recommendedSizes": [
-                            "Standard_D1_v2"
+                            "Standard_DS1_v2"
                         ],
                         "constraints": {
                             "allowedSizes": [
-                                "Standard_D1_v2",
-                                "Standard_D2_v2",
-                                "Standard_D2_v3",
-                                "Standard_D4_v3"
+                                "Standard_DS1_v2",
+                                "Standard_DS2_v2",
+                                "Standard_DS3_v2",
+                                "Standard_DS4_v2"
                             ]
                         },
                         "osPlatform": "Windows",

--- a/lab-1/begin/mainTemplate.json
+++ b/lab-1/begin/mainTemplate.json
@@ -54,7 +54,7 @@
         "subnetName": "subnet1",
         "osType": {
             "imageOffer": "Windows-10",
-            "imageSku": "rs5-pro",
+            "imageSku": "20h2-pro-g2",
             "imagePublisher": "MicrosoftWindowsDesktop"
         }
     },

--- a/lab-1/lab-1.md
+++ b/lab-1/lab-1.md
@@ -59,12 +59,8 @@ Clone the repository to your local machine.
     ![Storage account](./images/01.png)
 
 4. While going through the setup steps, use the following values.
-    - Storage account name > Some unique value
-    - Basics > Replication > Locally Redundant Storage (LRS)
-    - Networking > Network Connectivity > Public endpoint (all networks)
-    - Data Protection > Leave defaults
-    - Advanced > Leave defaults
-    - Tags > Leave defaults
+    - Basics > Storage account name > Some unique value
+    - Basics > Redundancy > Locally Redundant Storage (LRS)
 
 5. Create a new container in blob storage.
 
@@ -79,7 +75,7 @@ Clone the repository to your local machine.
  
 ## Upload app.zip
 
-1. Click into the new container.
+1. Click into the newly created container.
 2. Select “Upload.”
 3. Browse to app.zip and upload the file.
 4. Right click the new blob and select > Properties.


### PR DESCRIPTION
Combination of existing VM size and image is not longer supported (Standard_D1_v2 and Windows 10 pro).

Fix error:
"code": "InvalidParameter",
                "target": "imageReference",
                "message": "The following list of images referenced from the deployment template are not found: Publisher: MicrosoftWindowsDesktop, Offer: Windows-10, Sku: rs5-pro, Version: latest. Please refer to https://docs.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage for instructions on finding available images."